### PR TITLE
Persist traps and add snapshot syncing

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ A multi-page web application for organizing spots on a grid map, built with Node
 - **Mobile Optimization**: Smaller grid and touch-friendly interface on mobile
 - **Zoom Control**: Adjustable zoom level (55% - 200%)
 - **Bear Trap Highlight**: manage up to two 2×2 zones via a popup after clicking the map
+- **Trap Persistence**: Trap locations and colors stored server-side and shared across devices
 - **Hover Effects**: Interactive highlighting and tooltips
 - **Modal Dialogs**: Clean add/edit interface
 - **Real-time Updates**: Instant reflection of changes
@@ -117,8 +118,17 @@ whiteout-spot-organizer/
 - `DELETE /api/cities/:id` - Delete city
 
 ### Import/Export
-- `GET /api/export` - Export all cities as JSON
-- `POST /api/import` - Import cities from JSON (replaces all data)
+- `GET /api/export` - Export all cities and traps as JSON (versioned payload)
+- `POST /api/import` - Import cities and traps from JSON (replaces all data)
+
+### Traps CRUD
+- `GET /api/traps` - List traps (public)
+- `POST /api/traps` - Create or replace trap (admin only)
+- `PUT /api/traps/:id` - Update trap (admin only)
+- `DELETE /api/traps/:id` - Remove trap (admin only)
+
+### Snapshot
+- `GET /api/snapshot` - Combined cities & traps with ETag for syncing
 
 ### Users CRUD
 - `GET /api/users` - List users
@@ -167,8 +177,8 @@ whiteout-spot-organizer/
 
 ### Bear Traps (Admin Only)
 1. Click an empty tile on the map to open the action popup.
-2. Choose **Trap 1** or **Trap 2** to place a 2×2 trap, or select **Insert City** to add a city instead.
-3. To remove a trap, click any tile within its area and use **Delete Trap** in the popup.
+2. Choose **Trap 1** or **Trap 2** and pick a color to place a 2×2 trap, or select **Insert City** to add a city instead.
+3. Click any trapped tile to adjust its color or use **Delete Trap**.
 
 ### Searching and Filtering
 - Use the search box to find cities by name
@@ -209,6 +219,15 @@ CREATE TABLE cities (
   y INTEGER NOT NULL,
   notes TEXT,
   color TEXT DEFAULT '#ec4899'
+);
+
+CREATE TABLE traps (
+  id TEXT PRIMARY KEY,
+  slot INTEGER UNIQUE CHECK(slot IN (1,2)),
+  x INTEGER NOT NULL,
+  y INTEGER NOT NULL,
+  color TEXT NOT NULL DEFAULT '#f59e0b',
+  notes TEXT
 );
 ```
 

--- a/db.js
+++ b/db.js
@@ -17,6 +17,7 @@ const DB_PATH = path.extname(envPath) === DB_EXTENSION ? envPath : `${envPath}${
 
 const TABLES = {
   CITIES: 'cities',
+  TRAPS: 'traps',
   USERS: 'users',
   AUDIT: 'audit_logs',
 };
@@ -46,6 +47,14 @@ function initializeDatabase() {
       y INTEGER NOT NULL,
       notes TEXT,
       color TEXT DEFAULT '#ec4899'
+    );
+    CREATE TABLE IF NOT EXISTS ${TABLES.TRAPS} (
+      id TEXT PRIMARY KEY,
+      slot INTEGER UNIQUE CHECK(slot IN (1,2)),
+      x INTEGER NOT NULL,
+      y INTEGER NOT NULL,
+      color TEXT NOT NULL DEFAULT '#f59e0b',
+      notes TEXT
     );
     CREATE TABLE IF NOT EXISTS ${TABLES.AUDIT} (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -113,6 +122,7 @@ function ensureUsersTable() {
 
 function clearDatabase() {
   runQuery(`DELETE FROM ${TABLES.CITIES}`);
+  runQuery(`DELETE FROM ${TABLES.TRAPS}`);
   runQuery(`DELETE FROM ${TABLES.USERS}`);
   runQuery(`DELETE FROM ${TABLES.AUDIT}`);
 }

--- a/public/map.html
+++ b/public/map.html
@@ -124,14 +124,21 @@
         <button type="button" id="closeTrapModal" class="p-2 rounded-lg hover:bg-slate-800">✕</button>
       </div>
       <div id="trapPlaceSection" class="p-4 flex flex-col gap-3">
+        <label class="text-sm" for="trapColor">Color</label>
+        <input id="trapColor" type="color" value="#f59e0b" class="h-8 w-full">
         <button type="button" id="addCityOption" class="px-3 py-2 rounded-xl bg-indigo-600 hover:bg-indigo-500 text-sm">Insert City</button>
         <div class="flex gap-2">
           <button type="button" class="trapOption px-3 py-2 rounded-xl bg-sky-600 hover:bg-sky-500 text-sm" data-index="0">Trap 1</button>
           <button type="button" class="trapOption px-3 py-2 rounded-xl bg-sky-600 hover:bg-sky-500 text-sm" data-index="1">Trap 2</button>
         </div>
       </div>
-      <div id="trapDeleteSection" class="p-4 flex justify-end gap-2 hidden">
-        <button type="button" id="deleteTrapBtn" class="px-3 py-2 rounded-xl bg-rose-600 hover:bg-rose-500 text-sm">Delete Trap</button>
+      <div id="trapDeleteSection" class="p-4 flex flex-col gap-3 hidden">
+        <label class="text-sm" for="trapEditColor">Color</label>
+        <input id="trapEditColor" type="color" class="h-8 w-full">
+        <div class="flex justify-end gap-2">
+          <button type="button" id="saveTrapBtn" class="px-3 py-2 rounded-xl bg-indigo-600 hover:bg-indigo-500 text-sm">Save</button>
+          <button type="button" id="deleteTrapBtn" class="px-3 py-2 rounded-xl bg-rose-600 hover:bg-rose-500 text-sm">Delete Trap</button>
+        </div>
       </div>
     </form>
   </dialog>

--- a/tests/database.test.js
+++ b/tests/database.test.js
@@ -26,6 +26,14 @@ function createTestDB() {
       notes TEXT,
       color TEXT DEFAULT '#ec4899'
     );
+    CREATE TABLE IF NOT EXISTS traps (
+      id TEXT PRIMARY KEY,
+      slot INTEGER UNIQUE CHECK(slot IN (1,2)),
+      x INTEGER NOT NULL,
+      y INTEGER NOT NULL,
+      color TEXT NOT NULL DEFAULT '#f59e0b',
+      notes TEXT
+    );
     CREATE TABLE IF NOT EXISTS users (
       id TEXT PRIMARY KEY,
       username TEXT NOT NULL,

--- a/tests/traps.test.js
+++ b/tests/traps.test.js
@@ -1,0 +1,58 @@
+const request = require('supertest');
+const fs = require('fs');
+
+const TEST_DB = 'traps-test.db';
+const ADMIN = { username: 'admin', password: 'admin' };
+let app;
+
+beforeAll(() => {
+  if (fs.existsSync(TEST_DB)) {
+    fs.unlinkSync(TEST_DB);
+  }
+  process.env.DB_PATH = TEST_DB;
+  app = require('../server');
+});
+
+afterAll(() => {
+  if (fs.existsSync(TEST_DB)) {
+    fs.unlinkSync(TEST_DB);
+  }
+});
+
+describe('Trap API', () => {
+  test('public GET and auth-required mutations', async () => {
+    await request(app).get('/api/traps').expect(200);
+    await request(app).post('/api/traps').send({}).expect(401);
+
+    const login = await request(app)
+      .post('/api/login')
+      .send(ADMIN);
+    const cookie = login.headers['set-cookie'];
+
+    const payload = { id: 't1', slot: 1, x: 0, y: 0, color: '#f59e0b' };
+    await request(app)
+      .post('/api/traps')
+      .set('Cookie', cookie)
+      .send(payload)
+      .expect(200);
+
+    const trapsRes = await request(app).get('/api/traps').expect(200);
+    expect(trapsRes.body.length).toBe(1);
+
+    await request(app)
+      .delete('/api/traps/t1')
+      .set('Cookie', cookie)
+      .expect(200);
+  });
+});
+
+describe('Snapshot ETag', () => {
+  test('returns 304 when data unchanged', async () => {
+    const res1 = await request(app).get('/api/snapshot').expect(200);
+    const etag = res1.headers['etag'];
+    await request(app)
+      .get('/api/snapshot')
+      .set('If-None-Match', etag)
+      .expect(304);
+  });
+});


### PR DESCRIPTION
## Summary
- store trap positions and colors in a new `traps` table
- expose trap CRUD endpoints and snapshot API with ETag
- refresh client views and export/import to include traps

