### PR TITLE
Add configurable level colors and auto city coloring

### DIFF
--- a/db.js
+++ b/db.js
@@ -20,6 +20,7 @@ const TABLES = {
   TRAPS: 'traps',
   USERS: 'users',
   AUDIT: 'audit_logs',
+  LEVELS: 'level_colors',
 };
 
 const USER_PASSWORD_COLUMN = 'password';
@@ -56,6 +57,10 @@ function initializeDatabase() {
       color TEXT NOT NULL DEFAULT '#f59e0b',
       notes TEXT
     );
+    CREATE TABLE IF NOT EXISTS ${TABLES.LEVELS} (
+      level INTEGER PRIMARY KEY,
+      color TEXT NOT NULL
+    );
     CREATE TABLE IF NOT EXISTS ${TABLES.AUDIT} (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       entity TEXT NOT NULL,
@@ -66,6 +71,21 @@ function initializeDatabase() {
   `);
 
   ensureUsersTable();
+
+  // Seed default level colors (1-5)
+  const defaultLevelColors = {
+    1: '#ef4444',
+    2: '#f59e0b',
+    3: '#10b981',
+    4: '#3b82f6',
+    5: '#8b5cf6',
+  };
+  for (const [level, color] of Object.entries(defaultLevelColors)) {
+    runQuery(
+      `INSERT OR IGNORE INTO ${TABLES.LEVELS} (level, color) VALUES (?, ?)`,
+      [level, color]
+    );
+  }
 
   const admin = getQuery(
     `SELECT ${USER_PASSWORD_COLUMN} FROM ${TABLES.USERS} WHERE username = ?`,

--- a/public/js/levels.js
+++ b/public/js/levels.js
@@ -1,0 +1,45 @@
+let isAdmin = false;
+
+async function checkAdmin() {
+  const user = await Auth.fetchUser();
+  isAdmin = Auth.isManager();
+  const saveBtn = document.getElementById('saveBtn');
+  if (!isAdmin) saveBtn.style.display = 'none';
+}
+
+async function loadLevels() {
+  try {
+    const res = await fetch('/api/levels');
+    const data = await res.json();
+    for (const { level, color } of data) {
+      const input = document.getElementById(`level-${level}`);
+      if (input) input.value = color;
+    }
+  } catch (err) {
+    console.error('Failed to load level colors', err);
+  }
+}
+
+async function saveLevels() {
+  try {
+    for (let i = 1; i <= 5; i++) {
+      const color = document.getElementById(`level-${i}`).value;
+      await fetch('/api/levels', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ level: i, color })
+      });
+    }
+    alert('Level colors saved');
+  } catch (err) {
+    alert('Failed to save: ' + err.message);
+  }
+}
+
+document.getElementById('saveBtn').addEventListener('click', (e) => {
+  e.preventDefault();
+  saveLevels();
+});
+
+checkAdmin();
+loadLevels();

--- a/public/js/list.js
+++ b/public/js/list.js
@@ -7,6 +7,7 @@ let snapshotEtag = null;
 /** @type {Array<{id:string,name:string,level?:number,status:'occupied'|'reserved',x:number,y:number,notes?:string,color:string}>} */
 let cities = [];
 let filteredCities = [];
+let levelColors = {};
 
 // Admin functionality
 let isAdmin = false;
@@ -77,6 +78,20 @@ const xEl = document.getElementById('x');
 const yEl = document.getElementById('y');
 const notesEl = document.getElementById('notes');
 const colorEl = document.getElementById('color');
+levelEl.addEventListener('input', () => {
+  colorEl.value = levelColors[levelEl.value] || '#ec4899';
+});
+
+async function loadLevelColors() {
+  try {
+    const res = await fetch('/api/levels');
+    const data = await res.json();
+    levelColors = {};
+    for (const entry of data) levelColors[entry.level] = entry.color;
+  } catch (err) {
+    console.error('Failed to load level colors', err);
+  }
+}
 
 // ===== API Functions =====
 async function loadSnapshot(force = false) {
@@ -372,7 +387,7 @@ function openCreateAt(x, y) {
   xEl.value = x;
   yEl.value = y;
   notesEl.value = '';
-  colorEl.value = '#ec4899';
+  colorEl.value = levelColors[levelEl.value] || '#ec4899';
   deleteBtn.classList.add('hidden');
   cityModal.showModal();
 }
@@ -386,7 +401,7 @@ function openEdit(c) {
   xEl.value = c.x;
   yEl.value = c.y;
   notesEl.value = c.notes || '';
-  colorEl.value = c.color || '#ec4899';
+  colorEl.value = levelColors[c.level] || '#ec4899';
   deleteBtn.classList.remove('hidden');
   cityModal.showModal();
 }
@@ -583,6 +598,7 @@ function runTests() {
 // ===== Boot =====
 checkAdminStatus();
 buildGrid();
+loadLevelColors();
 loadSnapshot();
 setInterval(() => loadSnapshot(), 5000);
 requestAnimationFrame(centerView);

--- a/public/js/map.js
+++ b/public/js/map.js
@@ -8,6 +8,7 @@ let snapshotEtag = null;
 
 /** @type {Array<{id:string,name:string,level?:number,status:'occupied'|'reserved',x:number,y:number,notes?:string,color:string}>} */
 let cities = [];
+let levelColors = {};
 
 // Admin functionality
 let isAdmin = false;
@@ -122,6 +123,20 @@ const xEl = document.getElementById('x');
 const yEl = document.getElementById('y');
 const notesEl = document.getElementById('notes');
 const colorEl = document.getElementById('color');
+levelEl.addEventListener('input', () => {
+  colorEl.value = levelColors[levelEl.value] || '#ec4899';
+});
+
+async function loadLevelColors() {
+  try {
+    const res = await fetch('/api/levels');
+    const data = await res.json();
+    levelColors = {};
+    for (const entry of data) levelColors[entry.level] = entry.color;
+  } catch (err) {
+    console.error('Failed to load level colors', err);
+  }
+}
 
 // ===== API Functions =====
 async function loadSnapshot(force = false) {
@@ -419,7 +434,7 @@ function openCreateAt(x, y) {
   xEl.value = x;
   yEl.value = y;
   notesEl.value = '';
-  colorEl.value = '#ec4899';
+  colorEl.value = levelColors[levelEl.value] || '#ec4899';
   deleteBtn.classList.add('hidden');
   cityModal.showModal();
 }
@@ -433,7 +448,7 @@ function openEdit(c) {
   xEl.value = c.x;
   yEl.value = c.y;
   notesEl.value = c.notes || '';
-  colorEl.value = c.color || '#ec4899';
+  colorEl.value = levelColors[c.level] || '#ec4899';
   deleteBtn.classList.remove('hidden');
   cityModal.showModal();
 }
@@ -743,6 +758,7 @@ function runTests() {
 // ===== Boot =====
 checkAdminStatus();
 buildGrid();
+loadLevelColors();
 loadSnapshot();
 setInterval(() => loadSnapshot(), 5000);
 requestAnimationFrame(centerView);

--- a/public/levels.html
+++ b/public/levels.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Whiteout Spot Organizer - Level Colors</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="css/tailwind.css">
+</head>
+<body class="h-full bg-slate-900 text-slate-100">
+  <div class="h-full flex flex-col">
+    <header class="sticky top-0 z-50 backdrop-blur bg-slate-900/70 border-b border-slate-800">
+      <div class="px-3 sm:px-4 py-3 flex items-center gap-3">
+        <div class="flex items-center gap-2">
+          <span class="text-xl font-bold tracking-tight">ZOM WOS Spot Organizer</span>
+          <span class="text-[10px] uppercase px-2 py-0.5 rounded-full bg-indigo-600/30 text-indigo-200 border border-indigo-400/30">Beta</span>
+        </div>
+        <div class="ml-auto flex items-center gap-3">
+          <a href="/map" class="text-indigo-300 hover:text-indigo-200 underline underline-offset-4">Map View</a>
+          <a href="/list" class="text-indigo-300 hover:text-indigo-200 underline underline-offset-4">List View</a>
+          <button id="themeToggle" class="p-2 rounded-lg hover:bg-slate-800" title="Toggle theme">🌗</button>
+        </div>
+      </div>
+    </header>
+
+    <main class="flex-1 min-h-0 p-4">
+      <div class="max-w-md mx-auto space-y-4">
+        <h1 class="text-2xl font-bold">🎨 Level Colors</h1>
+        <form id="levelsForm" class="space-y-4">
+          <div>
+            <label class="text-xs text-slate-300">Level 1</label>
+            <input id="level-1" type="color" class="mt-1 w-full h-10 rounded-xl bg-slate-800 border border-slate-700" />
+          </div>
+          <div>
+            <label class="text-xs text-slate-300">Level 2</label>
+            <input id="level-2" type="color" class="mt-1 w-full h-10 rounded-xl bg-slate-800 border border-slate-700" />
+          </div>
+          <div>
+            <label class="text-xs text-slate-300">Level 3</label>
+            <input id="level-3" type="color" class="mt-1 w-full h-10 rounded-xl bg-slate-800 border border-slate-700" />
+          </div>
+          <div>
+            <label class="text-xs text-slate-300">Level 4</label>
+            <input id="level-4" type="color" class="mt-1 w-full h-10 rounded-xl bg-slate-800 border border-slate-700" />
+          </div>
+          <div>
+            <label class="text-xs text-slate-300">Level 5</label>
+            <input id="level-5" type="color" class="mt-1 w-full h-10 rounded-xl bg-slate-800 border border-slate-700" />
+          </div>
+        </form>
+        <button id="saveBtn" class="px-3 py-2 rounded-xl bg-indigo-600 hover:bg-indigo-500 text-sm">Save</button>
+      </div>
+    </main>
+  </div>
+
+  <script src="js/theme.js"></script>
+  <script src="js/auth.js"></script>
+  <script src="js/levels.js"></script>
+</body>
+</html>

--- a/public/list.html
+++ b/public/list.html
@@ -137,8 +137,8 @@
           <input id="y" type="number" class="mt-1 w-full rounded-xl bg-slate-800 border border-slate-700 px-3 py-2" />
         </div>
         <div class="col-span-2">
-          <label class="text-xs text-slate-300">Color</label>
-          <input id="color" type="color" value="#ec4899" class="mt-1 w-full h-10 rounded-xl bg-slate-800 border border-slate-700" />
+          <label class="text-xs text-slate-300">Color (auto)</label>
+          <input id="color" type="color" value="#ec4899" disabled class="mt-1 w-full h-10 rounded-xl bg-slate-800 border border-slate-700" />
         </div>
         <div class="col-span-2">
           <label class="text-xs text-slate-300">Notes</label>
@@ -164,6 +164,7 @@
        <a href="/list" class="block px-3 py-2 text-sm text-slate-200 hover:bg-slate-700 rounded bg-slate-700">📋 List View</a>
        <a href="/history" class="block px-3 py-2 text-sm text-slate-200 hover:bg-slate-700 rounded">📜 Edit History</a>
        <a href="/users" class="block px-3 py-2 text-sm text-slate-200 hover:bg-slate-700 rounded">👥 Users & Audit</a>
+       <a href="/levels" class="block px-3 py-2 text-sm text-slate-200 hover:bg-slate-700 rounded">🎨 Level Colors</a>
        <hr class="border-slate-600 my-1">
        <button id="adminLoginBtn" class="block w-full text-left px-3 py-2 text-sm text-slate-200 hover:bg-slate-700 rounded">🔐 Admin Login</button>
        <button id="logoutBtn" class="hidden block w-full text-left px-3 py-2 text-sm text-red-300 hover:bg-slate-700 rounded">🚪 Logout</button>

--- a/public/map.html
+++ b/public/map.html
@@ -96,8 +96,8 @@
           <input id="y" type="number" class="mt-1 w-full rounded-xl bg-slate-800 border border-slate-700 px-3 py-2" />
         </div>
         <div class="col-span-2">
-          <label class="text-xs text-slate-300">Color</label>
-          <input id="color" type="color" value="#ec4899" class="mt-1 w-full h-10 rounded-xl bg-slate-800 border border-slate-700" />
+          <label class="text-xs text-slate-300">Color (auto)</label>
+          <input id="color" type="color" value="#ec4899" disabled class="mt-1 w-full h-10 rounded-xl bg-slate-800 border border-slate-700" />
         </div>
         <div class="col-span-2">
           <label class="text-xs text-slate-300">Notes</label>
@@ -157,6 +157,7 @@
         <a href="/list" class="block px-3 py-2 text-sm text-slate-200 hover:bg-slate-700 rounded">📋 List View</a>
         <a href="/history" class="block px-3 py-2 text-sm text-slate-200 hover:bg-slate-700 rounded">📜 Edit History</a>
         <a href="/users" class="block px-3 py-2 text-sm text-slate-200 hover:bg-slate-700 rounded">👥 Users & Audit</a>
+        <a href="/levels" class="block px-3 py-2 text-sm text-slate-200 hover:bg-slate-700 rounded">🎨 Level Colors</a>
         <hr class="border-slate-600 my-1">
         <button id="adminLoginBtn" class="block w-full text-left px-3 py-2 text-sm text-slate-200 hover:bg-slate-700 rounded">🔐 Admin Login</button>
         <button id="logoutBtn" class="hidden block w-full text-left px-3 py-2 text-sm text-red-300 hover:bg-slate-700 rounded">🚪 Logout</button>

--- a/tests/database.test.js
+++ b/tests/database.test.js
@@ -34,6 +34,10 @@ function createTestDB() {
       color TEXT NOT NULL DEFAULT '#f59e0b',
       notes TEXT
     );
+    CREATE TABLE IF NOT EXISTS level_colors (
+      level INTEGER PRIMARY KEY,
+      color TEXT NOT NULL
+    );
     CREATE TABLE IF NOT EXISTS users (
       id TEXT PRIMARY KEY,
       username TEXT NOT NULL,
@@ -48,6 +52,17 @@ function createTestDB() {
       timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
     );
   `);
+
+  const defaultLevelColors = {
+    1: '#ef4444',
+    2: '#f59e0b',
+    3: '#10b981',
+    4: '#3b82f6',
+    5: '#8b5cf6',
+  };
+  for (const [level, color] of Object.entries(defaultLevelColors)) {
+    db.prepare('INSERT OR IGNORE INTO level_colors (level, color) VALUES (?, ?)').run(level, color);
+  }
   
   return db;
 }
@@ -358,6 +373,14 @@ describe('Database CRUD Operations', () => {
       expect(logs[0].entity).toBe('cities');
       expect(logs[0].action).toBe('create');
       expect(logs[0].entity_id).toBe('city-1');
+    });
+  });
+
+  describe('Level colors table', () => {
+    test('should have default colors for levels 1-5', () => {
+      const levels = db.prepare('SELECT * FROM level_colors ORDER BY level').all();
+      expect(levels).toHaveLength(5);
+      expect(levels[0].color).toBe('#ef4444');
     });
   });
 });

--- a/tests/levels.test.js
+++ b/tests/levels.test.js
@@ -1,0 +1,46 @@
+const request = require('supertest');
+const fs = require('fs');
+
+const TEST_DB = 'levels-test.db';
+const ADMIN = { username: 'admin', password: 'admin' };
+let app;
+
+beforeAll(() => {
+  if (fs.existsSync(TEST_DB)) {
+    fs.unlinkSync(TEST_DB);
+  }
+  process.env.DB_PATH = TEST_DB;
+  app = require('../server');
+});
+
+afterAll(() => {
+  if (fs.existsSync(TEST_DB)) {
+    fs.unlinkSync(TEST_DB);
+  }
+});
+
+describe('Level color API', () => {
+  test('should get and update level colors', async () => {
+    const res = await request(app).get('/api/levels').expect(200);
+    expect(res.body.length).toBe(5);
+    const level1Color = res.body.find(l => l.level === 1).color;
+
+    const login = await request(app).post('/api/login').send(ADMIN);
+    const cookie = login.headers['set-cookie'];
+
+    await request(app)
+      .post('/api/cities')
+      .set('Cookie', cookie)
+      .send({ id: 'c1', name: 'City1', level: 1, status: 'occupied', x: 0, y: 0, notes: '', color: level1Color })
+      .expect(200);
+
+    await request(app)
+      .post('/api/levels')
+      .set('Cookie', cookie)
+      .send({ level: 1, color: '#123456' })
+      .expect(200);
+
+    const citiesRes = await request(app).get('/api/cities').expect(200);
+    expect(citiesRes.body[0].color).toBe('#123456');
+  });
+});


### PR DESCRIPTION
## Summary
- add database table for level colors with default palette and seed values
- expose API to manage level colors and auto-apply colors to cities
- fetch level colors in map and list views, making color selection automatic and read-only
- add admin page for configuring level colors and corresponding tests

