### PR TITLE
Replace native alerts with SweetAlert and modern map prompt

### DIFF
--- a/public/history.html
+++ b/public/history.html
@@ -149,6 +149,8 @@
     </form>
   </dialog>
 
+  <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
+  <script src="js/alerts.js"></script>
   <script src="js/theme.js"></script>
   <script src="js/auth.js"></script>
   <script src="js/history.js"></script>

--- a/public/js/alerts.js
+++ b/public/js/alerts.js
@@ -1,0 +1,13 @@
+(function() {
+  const nativeAlert = window.alert;
+  window.alert = function(message) {
+    if (window.Swal) {
+      Swal.fire({
+        text: String(message),
+        confirmButtonColor: '#6366f1'
+      });
+    } else {
+      nativeAlert(message);
+    }
+  };
+})();

--- a/public/js/list.js
+++ b/public/js/list.js
@@ -432,8 +432,15 @@ cityForm.addEventListener('submit', async (e) => {
 deleteBtn.addEventListener('click', async () => {
   const id = idEl.value;
   if (!id) return;
-  
-  if (confirm('Are you sure you want to delete this city?')) {
+
+  const result = await Swal.fire({
+    title: 'Delete this city?',
+    icon: 'warning',
+    showCancelButton: true,
+    confirmButtonText: 'Delete'
+  });
+
+  if (result.isConfirmed) {
     const success = await deleteCity(id);
     if (success) {
       cityModal.close();

--- a/public/levels.html
+++ b/public/levels.html
@@ -53,6 +53,8 @@
     </main>
   </div>
 
+  <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
+  <script src="js/alerts.js"></script>
   <script src="js/theme.js"></script>
   <script src="js/auth.js"></script>
   <script src="js/levels.js"></script>

--- a/public/list.html
+++ b/public/list.html
@@ -195,9 +195,11 @@
      </form>
    </dialog>
 
-   <script src="js/grid.js"></script>
-   <script src="js/theme.js"></script>
-   <script src="js/auth.js"></script>
-   <script src="js/list.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
+  <script src="js/alerts.js"></script>
+  <script src="js/grid.js"></script>
+  <script src="js/theme.js"></script>
+  <script src="js/auth.js"></script>
+  <script src="js/list.js"></script>
  </body>
 </html>

--- a/public/map.html
+++ b/public/map.html
@@ -188,18 +188,8 @@
      </form>
   </dialog>
 
-  <!-- Info Popup -->
-  <dialog id="infoPopup" class="rounded-2xl bg-slate-900/95 border border-slate-700 p-0 text-slate-100 w-[240px]">
-    <div id="infoContent" class="p-4 space-y-1 text-sm"></div>
-    <div class="p-4 flex justify-end gap-2">
-      <button type="button" id="infoAddCityBtn" class="hidden px-3 py-2 rounded-xl bg-indigo-600 hover:bg-indigo-500 text-sm">Add City</button>
-      <button type="button" id="infoAddBearBtn" class="hidden px-3 py-2 rounded-xl bg-sky-600 hover:bg-sky-500 text-sm">Add Bear</button>
-      <button type="button" id="infoEditBtn" class="hidden px-3 py-2 rounded-xl bg-indigo-600 hover:bg-indigo-500 text-sm">Edit</button>
-      <button type="button" id="infoDeleteBtn" class="hidden px-3 py-2 rounded-xl bg-rose-600 hover:bg-rose-500 text-sm">Delete</button>
-      <button type="button" id="infoCloseBtn" class="px-3 py-2 rounded-xl bg-slate-700 hover:bg-slate-600 text-sm">Close</button>
-    </div>
-  </dialog>
-
+  <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
+  <script src="js/alerts.js"></script>
   <script src="js/grid.js"></script>
   <script src="js/theme.js"></script>
   <script src="js/auth.js"></script>

--- a/public/users.html
+++ b/public/users.html
@@ -227,6 +227,8 @@
     </form>
   </dialog>
 
+  <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
+  <script src="js/alerts.js"></script>
   <script src="js/theme.js"></script>
   <script src="js/auth.js"></script>
   <script src="js/users.js"></script>


### PR DESCRIPTION
## Summary
- add a SweetAlert wrapper to replace native `alert` dialogs across the app
- prompt users with SweetAlert when clicking the map to add a city or bear trap
- update deletion and data-clearing confirmations to use SweetAlert
